### PR TITLE
Fix/implementing feedback

### DIFF
--- a/examples/typescript/attestation-flow-guides/src/lit/lit-helpers/decrypt-attestation-data.ts
+++ b/examples/typescript/attestation-flow-guides/src/lit/lit-helpers/decrypt-attestation-data.ts
@@ -1,7 +1,7 @@
 import { LitNodeClient } from "@lit-protocol/lit-node-client";
 import { generateAuthSig, createSiweMessage, LitAccessControlConditionResource, LitActionResource } from "@lit-protocol/auth-helpers";
 import { LIT_ABILITY } from "@lit-protocol/constants";
-import { ethers } from "ethers";
+import type { ethers } from "ethers";
 
 import { LitDecryptionResponse, SiwsMessageForFormatting } from "../types";
 import { litActionCode as litActionCodeDecrypt } from "./lit-action-decrypt";

--- a/examples/typescript/attestation-flow-guides/src/lit/lit-helpers/lit-action-decrypt.ts
+++ b/examples/typescript/attestation-flow-guides/src/lit/lit-helpers/lit-action-decrypt.ts
@@ -214,7 +214,7 @@ const _litActionCode = async () => {
       const isValid = await crypto.subtle.verify(
         "Ed25519",
         publicKey,
-        ethers.utils.base58.decode(siwsMessageSignature),
+        ethers.utils.arrayify(`0x${siwsMessageSignature}`),
         new TextEncoder().encode(siwsMessage)
       );
 
@@ -345,9 +345,7 @@ const _litActionCode = async () => {
       ciphertext,
       dataToEncryptHash,
       authSig: {
-        sig: ethers.utils
-          .hexlify(ethers.utils.base58.decode(siwsMessageSignature))
-          .slice(2),
+        sig: siwsMessageSignature,
         derivedVia: "solana.signMessage",
         signedMessage: siwsMessageString,
         address: siwsMessageJson.address,

--- a/examples/typescript/attestation-flow-guides/src/lit/lit-helpers/setup-lit.ts
+++ b/examples/typescript/attestation-flow-guides/src/lit/lit-helpers/setup-lit.ts
@@ -1,4 +1,4 @@
-import { LIT_NETWORK, LIT_RPC } from "@lit-protocol/constants";
+import { LIT_NETWORK } from "@lit-protocol/constants";
 import { LitNodeClient } from "@lit-protocol/lit-node-client";
 import { LIT_NETWORKS_KEYS } from "@lit-protocol/types";
 import { ethers } from "ethers";
@@ -12,8 +12,7 @@ export async function setupLit(
         debug?: boolean,
     } = {}) {
     const litPayerEthersWallet = new ethers.Wallet(
-        ethers.Wallet.createRandom().privateKey,
-        new ethers.providers.JsonRpcProvider(LIT_RPC.CHRONICLE_YELLOWSTONE)
+        ethers.Wallet.createRandom().privateKey
     );
 
     const litNodeClient = new LitNodeClient({

--- a/examples/typescript/attestation-flow-guides/src/lit/lit-helpers/sign-siws-message.ts
+++ b/examples/typescript/attestation-flow-guides/src/lit/lit-helpers/sign-siws-message.ts
@@ -1,4 +1,3 @@
-import { ethers } from "ethers";
 import { createSignableMessage, KeyPairSigner } from "gill";
 
 import { SiwsMessageForFormatting } from "../types";
@@ -8,13 +7,14 @@ import { formatSiwsMessage } from "./format-siws-message";
  * Signs a SIWS message using a Solana keypair signer
  * @param siwsMessage - The formatted SIWS message to sign
  * @param signer - The Solana KeyPairSigner from setupWallets
- * @returns Base58-encoded signature
+ * @returns Hex-encoded signature
  */
 export async function signSiwsMessage(siwsMessage: SiwsMessageForFormatting, signer: KeyPairSigner): Promise<string> {
     try {
         const message = createSignableMessage(new TextEncoder().encode(formatSiwsMessage(siwsMessage)));
         const signedMessage = await signer.signMessages([message]);
-        return ethers.utils.base58.encode(signedMessage[0][signer.address]);
+        // Convert signature bytes to hex string
+        return Buffer.from(signedMessage[0][signer.address]).toString('hex');
     } catch (error) {
         throw new Error(`Failed to sign SIWS message: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }

--- a/examples/typescript/attestation-flow-guides/src/lit/sas-standard-lit-demo.ts
+++ b/examples/typescript/attestation-flow-guides/src/lit/sas-standard-lit-demo.ts
@@ -33,7 +33,7 @@ import {
 import {
     estimateComputeUnitLimitFactory
 } from "gill/programs";
-import { ethers } from "ethers";
+import type { ethers } from "ethers";
 
 import { createSiwsMessage, decryptAttestationData, encryptAttestationData, setupLit, signSiwsMessage } from "./lit-helpers";
 import { AttestationEncryptionMetadata } from "./types";

--- a/examples/typescript/attestation-flow-guides/src/lit/sas-tokenized-lit-demo.ts
+++ b/examples/typescript/attestation-flow-guides/src/lit/sas-tokenized-lit-demo.ts
@@ -41,7 +41,7 @@ import {
     TOKEN_2022_PROGRAM_ADDRESS,
     estimateComputeUnitLimitFactory
 } from "gill/programs";
-import { ethers } from "ethers";
+import type { ethers } from "ethers";
 
 import { createSiwsMessage, decryptAttestationData, encryptAttestationData, setupLit, signSiwsMessage } from "./lit-helpers";
 import { AttestationEncryptionMetadata } from "./types";


### PR DESCRIPTION
Implemented [feedback](https://github.com/solana-foundation/solana-attestation-site/pull/48#pullrequestreview-3145239231):

- Imports `ethers` as a type instead of value where applicable 
- Replaces usage of `ethers.utils.base58.encode` for SIWS signature with `Buffer.from`
- Removes unnecessary ethers provider when creating random ethers wallet for Lit session sig generation